### PR TITLE
Use localStorage to handle preferences in javascript

### DIFF
--- a/futura_weather_redux/src/main.c
+++ b/futura_weather_redux/src/main.c
@@ -453,8 +453,6 @@ void init() {
 	prefs = preferences_load();
 	weather = weather_load_cache();
 	
-	preferences_send(prefs);
-    
     window_stack_push(window, true);
 }
 


### PR DESCRIPTION
I have changed how the preferences are handled, along the ideas you mentioned. Now both the watch app and the javascript part store their own copy of the preferences. 
It is a very simple and robust solution, seems to work very well and will solve the problem with the app reverting back to defaults. 
