### PR TITLE
Change yahoo "mostly cloudy" to use the cloud symbol

### DIFF
--- a/futura_weather_redux/src/js/pebble-js-app.js
+++ b/futura_weather_redux/src/js/pebble-js-app.js
@@ -276,9 +276,9 @@ function YahooWeatherProvider() {
 			case 25:       // Cold
 				return 15; // -> Cold icon
 			case 26:       // Cloudy
-				return 3;  // -> Cloudy icon
 			case 27:       // Mostly cloudy (night)
 			case 28:       // Mostly cloudy (day)
+				return 3;  // -> Cloudy icon
 			case 29:       // Partly cloudy (night)
 			case 30:       // Partly cloudy (day)
 			case 44:       // Partly cloudy


### PR DESCRIPTION
I changed yahoo weather providers "mostly cloudy" to use the cloud symbol, since that is what they use on their own site.
