### PR TITLE
Make sure we preserve UTF-8 from l10n.js to the watchface

### DIFF
--- a/futura_weather_redux/src/js/pebble-js-app.js
+++ b/futura_weather_redux/src/js/pebble-js-app.js
@@ -507,7 +507,7 @@ function queryify(obj) {
 
 
 
-var configURL = "http://kylewlacy.github.io/futura-weather-redux/v3-yrno/preferences.html";
+var configURL = "http://snaggen.github.io/futura-weather-redux/v3/preferences.html";
 
 var prefs = new Preferences();
 prefs.loadFromStorage();

--- a/futura_weather_redux/src/preferences.c
+++ b/futura_weather_redux/src/preferences.c
@@ -2,6 +2,32 @@
 #include "config.h"
 #include "weather.h"
 #include "preferences.h"
+#include <ctype.h>
+
+/* Converts a hex character to its integer value */
+char from_hex(char ch) {
+  return isdigit((int) ch) ? ch - '0' : tolower((int) ch) - 'a' + 10;
+}
+
+char *url_decode(const char *str, char *dst) {
+  const char *pstr = str;
+  char *pbuf = dst;
+  while (*pstr) {
+    if (*pstr == '%') {
+      if (pstr[1] && pstr[2]) {
+        *pbuf++ = from_hex(pstr[1]) << 4 | from_hex(pstr[2]);
+        pstr += 2;
+      }
+    } else if (*pstr == '+') { 
+      *pbuf++ = ' ';
+    } else {
+      *pbuf++ = *pstr;
+    }
+    pstr++;
+  }
+  *pbuf = '\0';
+  return 0;
+}
 
 Preferences* preferences_load() {
 	static Preferences prefs = {
@@ -96,6 +122,7 @@ void preferences_set(Preferences *prefs, DictionaryIterator *iter) {
 		prefs->weather_outdated_time = weather_outdated_time->value->int32;
 	if(language_code != NULL)
 		prefs->language_code = language_code->value->int32;
-	if(translation != NULL)
-		strcpy(prefs->translation, translation->value->cstring);
+	if(translation != NULL) {
+		url_decode(translation->value->cstring, prefs->translation);
+    }
 }


### PR DESCRIPTION
It seems that somewhere on the way from l10n.js to the javascript code, something converted the translations from UTF-8 to ascii, which failed to be displayed on the pebble. So I have made sure we double encode the translations, and the handle the decoding in the preferences.c 
This solves the problem, and I'm able to see the translations again on android. Please test this on iOS and see if it works there too. 
Note: Don't forget the changes in the preferences.html I have. I added the meta utf8 since that seemed more correct and doesn't break anything now. I also removed the encodeHtml from the tranlsation names, since that broke things. It works without it on Android (also tested the page in Firefox and chrome). 
